### PR TITLE
Reset RTV votes once it happens

### DIFF
--- a/lua/excl_mapvote/sv_force.lua
+++ b/lua/excl_mapvote/sv_force.lua
@@ -32,6 +32,7 @@ local function doRTV(p)
 
 	if table.Count(voters) >= needed then
 		EXCL_MAPVOTE:Start()
+		voters = {}
 	end
 end
 


### PR DESCRIPTION
People would continue to RTV after winning the RTV to spam the mapvote start until it breaks and selects a map randomly or their map gets chosen. This resets the votes so that it requires everyone to RTV again.